### PR TITLE
Remove auto seeding and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ docker-compose up --build
 
 API is started in port `7000` and Postgres database is started in port `5432`.
 
+To seed test data in to the database refer the [backend readme](https://github.com/chennaitricolor/wastexchange-be#dev-machine-setup).
+
 ## Create the .env file
 
 Copy the .env.sample and rename as .env file. Contact the team to get the actual values of the keys.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,4 +25,3 @@ services:
       DB_NAME: wastexchange_development
       DB_PWD: dev
       DB_USER: dev
-      SEED_DB: "true"


### PR DESCRIPTION
Removed auto seeding of test DB data. `SEED_DB` env is removed from backend code as it is not idempotent and fails when ran multiple times.
Add instructions on how to seed data manually.